### PR TITLE
Extended configuration for chrome directories and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,15 +109,17 @@ include_config "../deps/chroxy/config/config.exs"
 
 Ports, Proxy Host and Endpoint Scheme are managed via Env Vars.
 
-| Variable                          | Default       | Desc.                                                      |
-| :------------------------         | :------------ | :--------------------------------------------------------- |
-| CHROXY_CHROME_PORT_FROM           | 9222          | Starting port in the Chrome Browser port range             |
-| CHROXY_CHROME_PORT_TO             | 9223          | Last port in the Chrome Browser port range                 |
-| CHROXY_PROXY_HOST                 | "127.0.0.1"   | Host which is substituted to route connections via proxy   |
-| CHROXY_PROXY_PORT                 | 1331          | Port which proxy listener will accept connections on       |
-| CHROXY_ENDPOINT_SCHEME            | :http         | `HTTP` or `HTTPS`                                          |
-| CHROXY_ENDPOINT_PORT              | 1330          | HTTP API will register on this port                        |
-| CHROXY_CHROME_SERVER_PAGE_WAIT_MS | 50            | Milliseconds to wait after asking chrome to create a page  |
+| Variable                             | Default       | Desc.                                                      |
+| :------------------------            | :------------ | :--------------------------------------------------------- |
+| CHROXY_CHROME_PORT_FROM              | 9222          | Starting port in the Chrome Browser port range             |
+| CHROXY_CHROME_PORT_TO                | 9223          | Last port in the Chrome Browser port range                 |
+| CHROXY_PROXY_HOST                    | "127.0.0.1"   | Host which is substituted to route connections via proxy   |
+| CHROXY_PROXY_PORT                    | 1331          | Port which proxy listener will accept connections on       |
+| CHROXY_ENDPOINT_SCHEME               | :http         | `HTTP` or `HTTPS`                                          |
+| CHROXY_ENDPOINT_PORT                 | 1330          | HTTP API will register on this port                        |
+| CHROXY_CHROME_SERVER_PAGE_WAIT_MS    | 50            | Milliseconds to wait after asking chrome to create a page  |
+| CHROME_CHROME_SERVER_CRASH_DUMPS_DIR | "/tmp"        | Directory to which chrome will write crash dumps           |
+
 ## Components
 
 ### Proxy
@@ -146,8 +148,8 @@ resources after connections are closed.
     * provides the registered process with the option to add or change proxy
       options prior to downstream connection initialisation.
   * `@spec down(indentifier(), proxy_state) :: :ok`
-    * provides the registered process with a signal that the proxy connection 
-       is about to terminate, due to either _upstream_ or _downstream_ 
+    * provides the registered process with a signal that the proxy connection
+       is about to terminate, due to either _upstream_ or _downstream_
        connections closing.
 
 ### Chrome Browser Management
@@ -156,8 +158,8 @@ Chrome is the first browser supported, and the following server processes manage
 the communication and lifetime of the Chrome Browsers and Tabs.
 
 `Chroxy.ChromeProxy` - Implements `ProxyServer.Hook` for Chrome resource management
-* Exposes function `connection/1` which returns the websocket connection 
-    to the browser tab, with the proxy host and port substituted in order to 
+* Exposes function `connection/1` which returns the websocket connection
+    to the browser tab, with the proxy host and port substituted in order to
    route the connection via the underlying `ProxyServer` process.
 * Registers for callbacks from the underlying `ProxyServer`, implementing the
   `down/2` callback in order to clean up the Chrome resource when connections

--- a/README.md
+++ b/README.md
@@ -98,13 +98,28 @@ environment variables
 
 ### Chroxy as a Library
 
-If using Chroxy as a dependency of another mix projects you may wish to leverage
-the configuration implementation of Chroxy by including the _config_ like
-so in your `config/config.exs` file:
+``` elixir
+def deps do
+  [{:chroxy, "~> 1.3"}]
+end
+```
 
+If using Chroxy as a dependency of another mix projects you may wish to leverage
+the configuration implementation of Chroxy by replication the configuration in
+`"../deps/chroxy/config/config.exs"`.
+
+Example: Create a Page Session, Registering for Event and Navigating to URL
+
+``` elixir
+ws_addr = Chroxy.connection()
+{:ok, page} = ChromeRemoteInterface.PageSession.start_link(ws_url)
+ChromeRemoteInterface.RPC.Page.enable(page)
+ChromeRemoteInterface.PageSession.subscribe(page, "Page.loadEventFired", self())
+url = "https://github.com/holsee"
+{:ok, _} = ChromeRemoteInterface.RPC.Page.navigate(page, %{url: url})
+# Message Received by self() => {:chrome_remote_interface, "Page.loadEventFired", _}
 ```
-include_config "../deps/chroxy/config/config.exs"
-```
+
 ### Configuration Variables
 
 Ports, Proxy Host and Endpoint Scheme are managed via Env Vars.

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,7 @@ end
 config :logger,
   :console,
   metadata: [:request_id, :pid, :module],
-  level: :info
+  level: :debug
 
 config :chroxy,
   chrome_remote_debug_port_from: envar.("CHROXY_CHROME_PORT_FROM") || "9222",
@@ -46,4 +46,5 @@ config :chroxy, Chroxy.Endpoint,
 
 config :chroxy, Chroxy.ChromeServer,
   page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "200",
-  crash_dumps_dir: envar.("CHROME_CHROME_SERVER_CRASH_DUMPS_DIR") || "/tmp"
+  crash_dumps_dir: envar.("CHROME_CHROME_SERVER_CRASH_DUMPS_DIR") || "/tmp",
+  verbose_logging: 0

--- a/config/config.exs
+++ b/config/config.exs
@@ -26,10 +26,9 @@ envar = fn name ->
 end
 
 config :logger,
-  level: :debug
-
-config :logger, :console,
-  metadata: [:request_id, :pid, :module]
+  :console,
+  metadata: [:request_id, :pid, :module],
+  level: :info
 
 config :chroxy,
   chrome_remote_debug_port_from: envar.("CHROXY_CHROME_PORT_FROM") || "9222",
@@ -39,13 +38,12 @@ config :chroxy, Chroxy.ProxyListener,
   host: envar.("CHROXY_PROXY_HOST") || "127.0.0.1",
   port: envar.("CHROXY_PROXY_PORT") || "1331"
 
-config :chroxy, Chroxy.ProxyServer,
-  packet_trace: false
+config :chroxy, Chroxy.ProxyServer, packet_trace: false
 
 config :chroxy, Chroxy.Endpoint,
   scheme: :http,
   port: envar.("CHROXY_ENDPOINT_PORT") || "1330"
 
 config :chroxy, Chroxy.ChromeServer,
-  page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "50",
+  page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "200",
   crash_dumps_dir: envar.("CHROME_CHROME_SERVER_CRASH_DUMPS_DIR") || "/tmp"

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,7 +25,11 @@ envar = fn name ->
   end
 end
 
-config :logger, :console, metadata: [:request_id, :pid, :module]
+config :logger,
+  level: :debug
+
+config :logger, :console,
+  metadata: [:request_id, :pid, :module]
 
 config :chroxy,
   chrome_remote_debug_port_from: envar.("CHROXY_CHROME_PORT_FROM") || "9222",
@@ -35,10 +39,13 @@ config :chroxy, Chroxy.ProxyListener,
   host: envar.("CHROXY_PROXY_HOST") || "127.0.0.1",
   port: envar.("CHROXY_PROXY_PORT") || "1331"
 
+config :chroxy, Chroxy.ProxyServer,
+  packet_trace: false
+
 config :chroxy, Chroxy.Endpoint,
   scheme: :http,
   port: envar.("CHROXY_ENDPOINT_PORT") || "1330"
 
 config :chroxy, Chroxy.ChromeServer,
   page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "50",
-
+  crash_dumps_dir: envar.("CHROME_CHROME_SERVER_CRASH_DUMPS_DIR") || "/tmp"

--- a/config/config.exs
+++ b/config/config.exs
@@ -40,4 +40,5 @@ config :chroxy, Chroxy.Endpoint,
   port: envar.("CHROXY_ENDPOINT_PORT") || "1330"
 
 config :chroxy, Chroxy.ChromeServer,
-  page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "50"
+  page_wait_ms: envar.("CHROXY_CHROME_SERVER_PAGE_WAIT_MS") || "50",
+

--- a/lib/chroxy/chrome_server.ex
+++ b/lib/chroxy/chrome_server.ex
@@ -130,9 +130,12 @@ defmodule Chroxy.ChromeServer do
   @doc false
   def init(args) do
     config = Application.get_env(:chroxy, __MODULE__)
-    opts = default_opts()
-           |> Keyword.merge(config)
-           |> Keyword.merge(args)
+
+    opts =
+      default_opts()
+      |> Keyword.merge(config)
+      |> Keyword.merge(args)
+
     page_wait_ms = Keyword.get(config, :page_wait_ms) |> String.to_integer()
     send(self(), :launch)
     Process.send_after(self(), :stop_if_not_ready, @ready_check_ms)
@@ -177,23 +180,22 @@ defmodule Chroxy.ChromeServer do
 
   @doc false
   def handle_info(:launch, state = %{options: opts}) do
-
-      value_flags = ~w(
+    value_flags = ~w(
         --remote-debugging-port=#{opts[:chrome_port]}
         --crash-dumps-dir=#{opts[:crash_dumps_dir]}
         --v=#{opts[:verbose_logging]}
       )
 
-      chrome_path = String.replace(opts[:chrome_path], " ", "\\ ")
+    chrome_path = String.replace(opts[:chrome_path], " ", "\\ ")
 
-      command =
-        [chrome_path, opts[:chrome_flags], value_flags]
-        |> List.flatten()
-        |> Enum.join(" ")
+    command =
+      [chrome_path, opts[:chrome_flags], value_flags]
+      |> List.flatten()
+      |> Enum.join(" ")
 
-      {:ok, pid, os_pid} = Exexec.run_link(command, exec_options())
-      state = Map.merge(%{command: command, pid: pid, os_pid: os_pid}, state)
-      {:noreply, state}
+    {:ok, pid, os_pid} = Exexec.run_link(command, exec_options())
+    state = Map.merge(%{command: command, pid: pid, os_pid: os_pid}, state)
+    {:noreply, state}
   end
 
   def handle_info(:stop_if_not_ready, state = %{session: nil, os_pid: os_pid}) do
@@ -344,5 +346,4 @@ defmodule Chroxy.ChromeServer do
         "/usr/bin/google-chrome"
     end
   end
-
 end

--- a/lib/chroxy/chrome_server.ex
+++ b/lib/chroxy/chrome_server.ex
@@ -244,6 +244,13 @@ defmodule Chroxy.ChromeServer do
     {:noreply, state}
   end
 
+  def handle_info({device, pid, <<_::size(@log_head_size), ":VERBOSE1:", msg::binary>>}, state)
+    when device == :stdout or device == :stderr do
+    msg = String.replace(msg, "\r\n", "")
+    Logger.debug("[CHROME: #{inspect(pid)}] #{inspect(msg)}")
+    {:noreply, state}
+  end
+
   # TODO refactor messages from logs to remove "\r\n" once / create module to
   # handle log parsing
   def handle_info(
@@ -332,7 +339,7 @@ defmodule Chroxy.ChromeServer do
         --no-sandbox
         --incognito
       ),
-      verbose_logging: 1,
+      verbose_logging: 0,
       crash_dumps_dir: "/tmp"
     ]
   end

--- a/lib/chroxy/chrome_server.ex
+++ b/lib/chroxy/chrome_server.ex
@@ -188,7 +188,8 @@ defmodule Chroxy.ChromeServer do
           --remote-debugging-port=#{opts[:chrome_port]}
           --crash-dumps-dir=#{tmp_path}
           --user-data-dir=#{tmp_path}
-        )
+        ) ++ if Logger.level() == :debug, do: ["--v=1"], else: []
+
         chrome_path = String.replace(opts[:chrome_path], " ", "\\ ")
 
         command =
@@ -328,7 +329,6 @@ defmodule Chroxy.ChromeServer do
         --disable-background-networking
         --safebrowsing-disable-auto-update
         --enable-logging
-        --v=1
         --disable-sync
         --metrics-recording-only
         --disable-default-apps

--- a/test/chroxy_test.exs
+++ b/test/chroxy_test.exs
@@ -1,10 +1,25 @@
 defmodule ChroxyTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Chroxy
+
+  setup do
+    page_url = Chroxy.connection()
+    {:ok, page} = ChromeRemoteInterface.PageSession.start_link(page_url)
+    [page: page]
+  end
 
   test "connection should return ws:// endpoint" do
     endpoint = Chroxy.connection()
     ws_uri = URI.parse(endpoint)
     assert ws_uri.scheme == "ws"
+  end
+
+  test "can control page & register to events", context do
+    page = context.page
+    url = "https://github.com/holsee"
+    ChromeRemoteInterface.RPC.Page.enable(page)
+    ChromeRemoteInterface.PageSession.subscribe(page, "Page.loadEventFired", self())
+    {:ok, _} = ChromeRemoteInterface.RPC.Page.navigate(page, %{url: url})
+    assert_receive {:chrome_remote_interface, "Page.loadEventFired", _}, 5_000
   end
 end


### PR DESCRIPTION
**Directory / Path Configuration & Changes**

Added `CHROME_CHROME_SERVER_CRASH_DUMPS_DIR` configuration option replacing the use of `System.tmp_dir!/0` as chrome creates directories then tries to change the permissions on those directories which is forbidden in OSX when `/var` dir selected under SIC controls.

Removed the user directory selection as under `--incognito` this should be ephemeral and isolated per tab process anyway under incognito operation.

**Logging Controls**

Verbose Logging Off by Default and going via Debug logging level - In v1.3.x up until now the Verbose logging mode was enabled on Chrome as we were tracking down issues relating to chrome crashing when running within a container in ECS - which remains elusive 😭even with latest chrome beta.  The verbose logging added unrequired overhead and will now be disabled by default, and when enabled will go via the debug logging level regardless of the device being `stdout` or `stderr`. 

Proxy Communication Tracing Off by Default - The `ProxyServer` was dumping out all *Up/Downstream* messages, which was going to be decoded in order to assist with deciphering the protocol communications.  This feature (decoding the WebSocket frames) was aborted, as it added little value compared to the overhead. - As this is of limited usefulness documentation was omitted at this time.

Note: Further work on logging will be handled down the line when the log parsing code is refactored into its own module/process to offload the overhead from the `ChromeServer`.

**Testing**

Improvements leading to the better unit testing story with automatic page initialisation and disposal per test.

Added test which performs page interaction and event subscription in order to 

**README**

An example added showing how to create a Page Session directly via `ChromeRemoteInterface.PageSession` and `Chroxy.connection/0`.

Added hex package reference.
