### PR TITLE
Add a healthcheck endpoint

### DIFF
--- a/lib/chroxy/endpoint.ex
+++ b/lib/chroxy/endpoint.ex
@@ -20,6 +20,10 @@ defmodule Chroxy.Endpoint do
     send_resp(conn, 200, endpoint)
   end
 
+  get "/healthcheck" do
+    send_resp(conn, 200, "OK")
+  end
+
   match _ do
     send_resp(conn, 404, "oops")
   end


### PR DESCRIPTION
When deploying chroxy behind a loadbalancer it is helpful
to have a healthcheck to let the loadbalancer know the instance
is healthy and ready to receive traffic