### PR TITLE
Fix/issue 5 conn race

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Example: Create a Page Session, Registering for Event and Navigating to URL
 
 ``` elixir
 ws_addr = Chroxy.connection()
-{:ok, page} = ChromeRemoteInterface.PageSession.start_link(ws_url)
+{:ok, page} = ChromeRemoteInterface.PageSession.start_link(ws_addr)
 ChromeRemoteInterface.RPC.Page.enable(page)
 ChromeRemoteInterface.PageSession.subscribe(page, "Page.loadEventFired", self())
 url = "https://github.com/holsee"

--- a/lib/chroxy/application.ex
+++ b/lib/chroxy/application.ex
@@ -17,7 +17,8 @@ defmodule Chroxy.Application do
       Chroxy.ProxyListener.child_spec(proxy_opts),
       Chroxy.ChromeServer.Supervisor.child_spec(),
       Chroxy.BrowserPool.child_spec(),
-      Chroxy.Endpoint.child_spec()
+      Chroxy.Endpoint.child_spec(),
+      Chroxy.ProxyRouter.child_spec()
     ]
 
     Logger.info("Started application")

--- a/lib/chroxy/browser_pool.ex
+++ b/lib/chroxy/browser_pool.ex
@@ -127,8 +127,7 @@ defmodule Chroxy.BrowserPool.Chrome do
     case Chroxy.ChromeServer.ready(chrome) do
       :ready ->
         # when ready close the pages which are openned by default
-        # :ok = Chroxy.ChromeServer.close_all_pages(chrome)
-        :ok
+        :ok = Chroxy.ChromeServer.close_all_pages(chrome)
 
       :timeout ->
         # failed to become ready in an acceptable timeframe
@@ -150,7 +149,6 @@ defmodule Chroxy.BrowserPool.Chrome do
     {:ok, pid} = Chroxy.ChromeProxy.start_link(chrome: chrome)
     url = Chroxy.ChromeProxy.chrome_connection(pid)
     page_id = page_id({:url, url})
-    IO.inspect(page_id_url: page_id)
     Chroxy.ProxyRouter.put(page_id, pid)
     {:reply, url, state}
   end

--- a/lib/chroxy/browser_pool.ex
+++ b/lib/chroxy/browser_pool.ex
@@ -39,7 +39,7 @@ defmodule Chroxy.BrowserPool do
   Request new page websocket url.
   """
   def connection(browser) when is_supported(browser) do
-    GenServer.call(__MODULE__, {:connection, browser})
+    GenServer.call(__MODULE__, {:connection, browser}, 60_000)
   end
 
   ##

--- a/lib/chroxy/browser_pool.ex
+++ b/lib/chroxy/browser_pool.ex
@@ -176,9 +176,7 @@ defmodule Chroxy.BrowserPool.Chrome do
     Chroxy.ChromeServer.Supervisor.which_children()
     |> Enum.filter(fn
          ({_, p, :worker, _}) when is_pid(p) ->
-           # Only allow "Ready processes through", a short blocking readyness
-           # call will ensure this, whilst not blocking consumer for too long.
-           Chroxy.ChromeServer.ready(p, retries: 5, wait_ms: 10) == :ready
+           Chroxy.ChromeServer.ready(p) == :ready
          (_) -> false
        end)
     |> Enum.map(&elem(&1, 1))

--- a/lib/chroxy/proxy_router.ex
+++ b/lib/chroxy/proxy_router.ex
@@ -1,0 +1,56 @@
+defmodule Chroxy.ProxyRouter do
+  @moduledoc """
+  Maps connection metadata (such as page_id in case of Chrome) in order
+  to route incoming request to the correct browser process.
+  Will monitor browser processes and automatically remove regsitrations
+  if a browser process dies during the course of operation.
+  """
+
+  use GenServer
+
+  @tbl __MODULE__
+
+  def child_spec() do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, []},
+      restart: :permanent,
+      shutdown: 5000,
+      type: :worker
+    }
+  end
+
+  def start_link() do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    opts = [:public, :set, :named_table,
+            read_concurrency: true, write_concurrency: true]
+    :ets.new(@tbl, opts)
+    {:ok, %{table: @tbl}}
+  end
+
+  def put(key, proc) do
+    ref = Process.monitor(proc)
+    :ets.insert(@tbl, {key, proc, ref})
+  end
+
+  def get(key) do
+    case :ets.lookup(@tbl, key) do
+      [] -> nil
+      [{_, browser,_}|_] -> browser
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, _object, _reason}, state) do
+    # Delete all the registrations for process which has went down, as the
+    # lookups would no longer be valid after process dies.
+    @tbl
+    |> :ets.match_object({:_, :_, ref})
+    |> Enum.map(fn ob -> :ets.delete_object(@tbl, ob) end)
+    {:noreply, state}
+  end
+
+end
+

--- a/test/chroxy_test.exs
+++ b/test/chroxy_test.exs
@@ -2,6 +2,25 @@ defmodule ChroxyTest do
   use ExUnit.Case, async: true
   doctest Chroxy
 
+  setup_all :ready_up
+
+  def ready_up(true) do
+    IO.puts("Browsers Ready")
+    :ok
+  end
+  def ready_up(false) do
+    Process.sleep(1000)
+    ready_up(:_)
+  end
+  def ready_up(_) do
+    {from, _} = Application.get_env(:chroxy, :chrome_remote_debug_port_from) |> Integer.parse()
+    {to, _} = Application.get_env(:chroxy, :chrome_remote_debug_port_to) |> Integer.parse()
+    pool_size = Chroxy.BrowserPool.Chrome.pool() |> Enum.count()
+		port_count = to - from + 1
+    ready? = Kernel.==(pool_size, port_count)
+    ready_up(ready?)
+  end
+
   setup do
     page_url = Chroxy.connection()
     {:ok, page} = ChromeRemoteInterface.PageSession.start_link(page_url)
@@ -25,12 +44,12 @@ defmodule ChroxyTest do
 
   test "out of order connections" do
     # Create 2 connections
-    conn_0 = Chroxy.connection() |> IO.inspect()
-    conn_1 = Chroxy.connection() |> IO.inspect()
+    conn_0 = Chroxy.connection()
+    conn_1 = Chroxy.connection()
 
     # Connect to 2nd connection first
-    page_1 = ChromeRemoteInterface.PageSession.start_link(conn_1)
-    page_0 = ChromeRemoteInterface.PageSession.start_link(conn_0)
+    _page_1 = ChromeRemoteInterface.PageSession.start_link(conn_1)
+    _page_0 = ChromeRemoteInterface.PageSession.start_link(conn_0)
 
     # Should not have crashed
     assert true


### PR DESCRIPTION
Work In Progress 

Addresses #5 

TODO
* Add `ProxyRouter` to provide a means by which a Chrome Server can be looked up based on page id. ✅
* On connection request made, register the `ChromeProxy` (which holds the downstream connection information), against the chrome `page_id`, so that it can be dynamically looked up when the request comes in. ✅ 
* In `ProxyServer`: Extract the `page_id` from the client request, lookup the `ChromeProxy` and reprocess the incoming message from client, after initialisation of the downstream connection to Chrome. ✅ 
* Refactor the `ChromeProxy` `ProxyServer` relationship to use the callback interface defined by `Chroxy.ProxyServer.Hook`  ✅ 
* When requesting `pool()` there is a check to filter out any browsers which are not ready.  In tests we don't wish to start text execution until all browsers are ready (or we will see timeouts on slower machines such as those used in the CI). ✅

