### PR TITLE
Fix/delete page from proxy router

### DIFF
--- a/lib/chroxy/browser_pool.ex
+++ b/lib/chroxy/browser_pool.ex
@@ -148,23 +148,7 @@ defmodule Chroxy.BrowserPool.Chrome do
   def handle_call({:get_connection, chrome}, _from, state) do
     {:ok, pid} = Chroxy.ChromeProxy.start_link(chrome: chrome)
     url = Chroxy.ChromeProxy.chrome_connection(pid)
-    page_id = page_id({:url, url})
-    Chroxy.ProxyRouter.put(page_id, pid)
     {:reply, url, state}
-  end
-
-  def page_id({:url, url}) do
-    url
-    |> String.split("/")
-    |> List.last()
-  end
-
-  def page_id({:http_request, data}) do
-    data
-    |> String.split(" HTTP")
-    |> List.first()
-    |> String.split("GET /devtools/page/")
-    |> Enum.at(1)
   end
 
   @doc """

--- a/lib/chroxy/browser_pool.ex
+++ b/lib/chroxy/browser_pool.ex
@@ -64,7 +64,6 @@ defmodule Chroxy.BrowserPool do
     Logger.info("BrowserPool link #{inspect(pid)} exited: #{inspect(reason)}")
     {:noreply, state}
   end
-
 end
 
 defmodule Chroxy.BrowserPool.Chrome do
@@ -157,12 +156,13 @@ defmodule Chroxy.BrowserPool.Chrome do
   def pool() do
     Chroxy.ChromeServer.Supervisor.which_children()
     |> Enum.filter(fn
-         ({_, p, :worker, _}) when is_pid(p) ->
-           Chroxy.ChromeServer.ready(p) == :ready
-         (_) -> false
-       end)
+      {_, p, :worker, _} when is_pid(p) ->
+        Chroxy.ChromeServer.ready(p) == :ready
+
+      _ ->
+        false
+    end)
     |> Enum.map(&elem(&1, 1))
     |> Enum.sort()
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Chroxy.MixProject do
   def project do
     [
       app: :chroxy,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Chroxy.MixProject do
   def project do
     [
       app: :chroxy,
-      version: "0.3.2",
+      version: "0.4.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/chroxy_test.exs
+++ b/test/chroxy_test.exs
@@ -8,15 +8,17 @@ defmodule ChroxyTest do
     IO.puts("Browsers Ready")
     :ok
   end
+
   def ready_up(false) do
     Process.sleep(1000)
     ready_up(:_)
   end
+
   def ready_up(_) do
     {from, _} = Application.get_env(:chroxy, :chrome_remote_debug_port_from) |> Integer.parse()
     {to, _} = Application.get_env(:chroxy, :chrome_remote_debug_port_to) |> Integer.parse()
     pool_size = Chroxy.BrowserPool.Chrome.pool() |> Enum.count()
-		port_count = to - from + 1
+    port_count = to - from + 1
     ready? = Kernel.==(pool_size, port_count)
     ready_up(ready?)
   end
@@ -54,5 +56,4 @@ defmodule ChroxyTest do
     # Should not have crashed
     assert true
   end
-
 end


### PR DESCRIPTION
Addresses Issue #12 

* Moved `ProxyRouter` registration into `ChromeProxy` 
* Cleanup (delete) of registrations in `ProxyRouter` when page closes.