### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+.dockerignore
+# there are valid reasons to keep the .git, namely so that you can get the
+# current commit hash
+.git
+.log
+tmp
+
+# Mix artifacts
+_build
+deps
+*.ez
+
+# don't include our release builds
+releases
+
+# Generate on crash by the VM
+erl_crash.dump
+
+# Static artifacts
+node_modules
+priv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+########################################################################
+FROM elixir:1.8.1-slim
+
+ENV SHELL=/bin/sh
+ENV application_directory=/usr/src/app
+ENV ENABLE_XVBF=true
+
+RUN mkdir -p $application_directory
+
+WORKDIR $application_directory
+
+# Install utilities
+RUN apt-get update --fix-missing && apt-get -y upgrade
+
+RUN apt-get update \
+    && apt-get install -y gnupg2 g++ wget \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
+
+# Install latest chrome dev package.
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb
+
+# Add a chrome user and setup home dir.
+RUN groupadd --system chrome && \
+    useradd --system --create-home --gid chrome --groups audio,video chrome && \
+    mkdir --parents /home/chrome/reports && \
+    chown --recursive chrome:chrome /home/chrome && \
+    chown --recursive chrome:chrome $application_directory
+
+# Run everything after as non-privileged user.
+USER chrome
+
+ARG ERLANG_COOKIE
+ENV ERLANG_COOKIE $ERLANG_COOKIE
+ENV MIX_ENV=prod
+
+# Install Hex + Rebar
+RUN mix do local.hex --force, local.rebar --force
+
+# Cache & compile elixir deps
+COPY config/ $application_directory/config/
+COPY mix.exs mix.lock $application_directory/
+RUN mix deps.get --only $MIX_ENV
+RUN mix deps.compile
+
+# Get rest of application and compile
+COPY . $application_directory/
+RUN mix compile --no-deps-check
+
+RUN mix do deps.loadpaths --no-deps-check
+
+EXPOSE 4000
+ENV PORT=4000
+
+CMD ["mix", "run", "--no-halt"]


### PR DESCRIPTION
This PR adds a Dockerfile that includes the latest `google-chrome-stable` package (resolves #11).

With kubernetes I run it like this:

**deployment.yml**
```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: crawler
  namespace: default
  labels:
    app: myApp
    tier: crawler

spec:
  replicas: 1
  revisionHistoryLimit: 1
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 1
  selector:
    matchLabels:
      app: myApp
      tier: crawler
  template:
    metadata:
      labels:
        app: myApp
        tier: crawler
    spec:
      containers:
        - image: eu.gcr.io/..../...:latest # your consumer
          name: api
          imagePullPolicy: Always
          resources:
            requests:
              cpu: 30m
              memory: 100Mi
          ports:
            - containerPort: 4000
          env:
          - name: USER_AGENT
            value: ...
          - name: INSTANCE_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name

        # [START chroxy]
        - name: headless-chrome
          image: eu.gcr.io/..../chroxy:latest # chroxy
          imagePullPolicy: Always
          resources:
            requests:
              cpu: 30m
              memory: 100Mi
          env:
            - name: CHROXY_CHROME_PORT_FROM
              value: "9222"
            - name: CHROXY_CHROME_PORT_TO
              value: "9223"
          ports:
            - containerPort: 9222
            - containerPort: 9223
            - containerPort: 1331
            - containerPort: 1330
        # [END chroxy]
```

**service.yaml**
```yaml
apiVersion: v1
kind: Service
metadata:
  namespace: default
  name: crawler-api
  labels:
    app: myApp
    tier: crawler
spec:
  selector:
    app: myApp
    tier: crawler
  ports:
  - port: 4000
    protocol: TCP
```
