### PR TITLE
Added shared memory note and flag in docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ $ iex -S mix
 
 _Run Docker image_
 
+Note: Chrome required a bump in shared memory allocation when running within
+docker in order to function in a stable manner.
+
 Exposes 1330, and 1331 (default ports for connection api and chrome proxy endpoint).
 ```
 $ docker build . -t chroxy
-$ docker run -p 1330:1330 -p 1331:1331 chroxy
+$ docker run --shm-size 2G -p 1330:1330 -p 1331:1331 chroxy
 ```
 
 ## Operation Examples:


### PR DESCRIPTION
Adds note regarding shared memory which is required for the stable operation of chrome