### PR TITLE
Bumped elixir version ~> 1.7, dockerfile to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 language: elixir
+
 elixir:
-  - 1.6
+  - 1.7
   - 1.8
   - 1.9
 otp_release:
+  - 22.2
   - 21.3
   - 20.3
 
+jobs:
+  exclude:
+    - elixir: 1.9
+      otp_release: 20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ########################################################################
-FROM elixir:1.8.2-slim
+FROM elixir:1.9.4-slim
 
 ENV SHELL=/bin/sh
 ENV application_directory=/usr/src/app

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ docker in order to function in a stable manner.
 
 Exposes 1330, and 1331 (default ports for connection api and chrome proxy endpoint).
 ```
-$ docker build . -t chroxy
-$ docker run --shm-size 2G -p 1330:1330 -p 1331:1331 chroxy
+docker build . -t chroxy
+docker run --shm-size 2G -p 1330:1330 -p 1331:1331 chroxy
 ```
 
 ## Operation Examples:

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Chroxy.MixProject do
     [
       app: :chroxy,
       version: "0.6.2",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),


### PR DESCRIPTION
- Expansion of PR #43
- Dockerfile targets 1.9
- Min elixir version 1.7
- OTP 22 and elixir 1.7 added to CI