### PR TITLE
Keep ProxyListener running or die trying

### DIFF
--- a/lib/chroxy/proxy_listener.ex
+++ b/lib/chroxy/proxy_listener.ex
@@ -22,7 +22,7 @@ defmodule Chroxy.ProxyListener do
     %{
       id: __MODULE__,
       start: {__MODULE__, :start_link, [opts]},
-      restart: :transient,
+      restart: :permanent,
       shutdown: 5000,
       type: :worker
     }


### PR DESCRIPTION
Some time ago, we had a recurring issue in production where Chroxy was
running but we couldn't connect to it. Eventually I discovered that the
`ProxyListener` was not running - apparently it had failed and had not
been restarted due to the `:transient` configuration.

In our private fork, I modified ProxyListener to be `restart:
:permanent` instead of `:transient`. With this change, failures in the
`ProxyListener` will crash the application rather than having it continue
running but be unreachable.

If the application does crash, the production system should be
configured to restart it, using systemd or whatever.