### PR TITLE
Fixes permissions error when getting deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ ENV MIX_ENV=prod
 RUN mix do local.hex --force, local.rebar --force
 
 # Cache & compile elixir deps
-COPY config/ $application_directory/config/
-COPY mix.exs mix.lock $application_directory/
+COPY --chown=chrome config/ $application_directory/config/
+COPY --chown=chrome mix.exs mix.lock $application_directory/
 RUN mix deps.get --only $MIX_ENV
 RUN mix deps.compile
 
 # Get rest of application and compile
-COPY . $application_directory/
+COPY --chown=chrome . $application_directory/
 RUN mix compile --no-deps-check
 
 RUN mix do deps.loadpaths --no-deps-check


### PR DESCRIPTION
When attempting to build the container I saw the following error

```
** (File.Error) could not write to file "mix.lock": permission denied
    (elixir) lib/file.ex:1050: File.write!/3
    (mix) lib/mix/dep/lock.ex:38: Mix.Dep.Lock.write/1
    (mix) lib/mix/dep/fetcher.ex:109: Mix.Dep.Fetcher.do_finalize/3
    (mix) lib/mix/dep/fetcher.ex:17: Mix.Dep.Fetcher.all/3
    (mix) lib/mix/tasks/deps.get.ex:31: Mix.Tasks.Deps.Get.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
The command '/bin/sh -c mix deps.get --only $MIX_ENV' returned a non-zero code: 1
```

Fixes:
* Make sure mix.lock file is writeable
* Make sure all files are owned by same user